### PR TITLE
Fix #3

### DIFF
--- a/src/pageOverlay.css
+++ b/src/pageOverlay.css
@@ -23,6 +23,7 @@ html > shinebar {
     left: 0;
     right: 0;
     height: 0;
+    -webkit-transform: translate(0, -30px);
 }
 
 shinebar > iframe {

--- a/src/pageOverlay.js
+++ b/src/pageOverlay.js
@@ -26,12 +26,12 @@ ShineOverlay.prototype = {
     this.overlay.appendChild(this.frame)
     document.documentElement.appendChild(this.overlay)
   },
-  
+
   setHeight: function(height) {
     if (height) {
       this.overlay.style.height = height
     }
-    document.documentElement.style.marginTop = height
+    document.documentElement.style.webkitTransform = "translate(0,30px)"
     this.overlay.style.opacity = height ? 1 : 0
   },
 
@@ -41,7 +41,7 @@ ShineOverlay.prototype = {
     }.bind(this))
     this.setHeight(0)
   },
-  
+
   _display: function(url) {
     this.frame.setAttribute('src', chrome.extension.getURL(url))
   },
@@ -72,6 +72,7 @@ function removeBar() {
     shineBar.remove()
     shineBar = false
     console.log('Shine bar removed.')
+    document.documentElement.style.webkitTransform = "translate(0,0)"
   }
 }
 


### PR DESCRIPTION
Fixed a issue when some page (like YouTube) uses `position:fixed` on the navbar. Instead of margin-top, I made a tranform in the entire html tag, pushing it down 30px with `-webkit-transform: translate(0,30px)` and pushing up the shinebar 30px with `-webkit-transform: translate(0,-30px)`. Guess it solves the problem, but I'm not sure if it has any side effects.
